### PR TITLE
Use httpclient instead of net_http

### DIFF
--- a/berkshelf-api-client.gemspec
+++ b/berkshelf-api-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 0.9.0"
-  spec.add_dependency "httpclient", "~> 2.5.3"
+  spec.add_dependency "httpclient", "~> 2.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/berkshelf-api-client.gemspec
+++ b/berkshelf-api-client.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 0.9.0"
+  spec.add_dependency "httpclient", "~> 2.5.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/berkshelf/api_client/connection.rb
+++ b/lib/berkshelf/api_client/connection.rb
@@ -43,7 +43,7 @@ module Berkshelf::APIClient
             Errno::ETIMEDOUT
           ]
 
-        b.adapter :net_http
+        b.adapter :httpclient
       end
 
       open_timeout = options.delete(:open_timeout)


### PR DESCRIPTION
This changes the default http adapter from net_http to httpclient and addresses this issue in berkshelf:

https://github.com/berkshelf/berkshelf/issues/1341

Of the avaialble Faraday adapters, httpclient is the only pure-ruby solution that supports the NO_PROXY environment variable.  This is essential for folks who have a private supermarket instance behind their firewall and only have access to the public supermarket through a proxy.

Currently, you can access public supermarket (by defining proxy vars) or private (by undefining same), but not both in a single berkshelf run.