### PR TITLE
Fixed typo in exception name.

### DIFF
--- a/lib/berkshelf/api_client/connection.rb
+++ b/lib/berkshelf/api_client/connection.rb
@@ -71,14 +71,14 @@ module Berkshelf::APIClient
       when 404
         raise ServiceNotFound, "service not found at: #{url}"
       when 500..504
-        raise ServiceUnavaiable, "service unavailable at: #{url}"
+        raise ServiceUnavailable, "service unavailable at: #{url}"
       else
         raise BadResponse, "bad response #{response.inspect}"
       end
     rescue Faraday::Error::TimeoutError, Errno::ETIMEDOUT
       raise TimeoutError, "Unable to connect to: #{url}"
     rescue Faraday::Error::ConnectionFailed => ex
-      raise ServiceUnavaiable, ex
+      raise ServiceUnavailable, ex
     end
   end
 end

--- a/lib/berkshelf/api_client/errors.rb
+++ b/lib/berkshelf/api_client/errors.rb
@@ -4,7 +4,7 @@ module Berkshelf
   module APIClient
     class TimeoutError < APIClientError; end
     class BadResponse < APIClientError; end
-    class ServiceUnavaiable < APIClientError; end
+    class ServiceUnavailable < APIClientError; end
     class ServiceNotFound < APIClientError; end
   end
 end

--- a/spec/unit/berkshelf/api_client/connection_spec.rb
+++ b/spec/unit/berkshelf/api_client/connection_spec.rb
@@ -59,8 +59,8 @@ describe Berkshelf::APIClient::Connection do
         instance.should_receive(:get).and_raise(Faraday::Error::ConnectionFailed.new(StandardError))
       end
 
-      it "raises a Berkshelf::APIClient::ServiceUnavaiable" do
-        expect { subject }.to raise_error(Berkshelf::APIClient::ServiceUnavaiable)
+      it "raises a Berkshelf::APIClient::ServiceUnavailable" do
+        expect { subject }.to raise_error(Berkshelf::APIClient::ServiceUnavailable)
       end
     end
   end


### PR DESCRIPTION
A modest PR to fix a typo in exception name.

Even if changing a constant name breaks API, I'm pretty sure that nobody rescues the exception with the typo in the name, or they would have submitted a PR already.