### PR TITLE
Removes the Gzip middleware from Faraday builder.

### DIFF
--- a/lib/berkshelf/api_client/connection.rb
+++ b/lib/berkshelf/api_client/connection.rb
@@ -34,7 +34,6 @@ module Berkshelf::APIClient
 
       options[:builder] ||= Faraday::RackBuilder.new do |b|
         b.response :parse_json
-        b.response :gzip
         b.request :retry,
           max: self.retries,
           interval: self.retry_interval,


### PR DESCRIPTION
I found this error while debugging issues with #9. It seems that the
Faraday httpclient has some sort of tuning set to [transparently use gzip
in the backaground](https://github.com/lostisland/faraday/blob/master/lib/faraday/adapter/httpclient.rb#L13-14). After removing this middleware I no longer saw the
error.

Not sure why nobody else saw this. Thoughts @reset?

```sh
~/Projects/omnibus-collectd % bin/berks install
Resolving cookbook dependencies...
Fetching cookbook index from https://supermarket.chef.io...
/home/jbellone/.gem/ruby/2.2.2/gems/ridley-4.2.0/lib/ridley/middleware/gzip.rb:9:in `initialize': not in gzip format (
Zlib::GzipFile::Error)
        from /home/jbellone/.gem/ruby/2.2.2/gems/ridley-4.2.0/lib/ridley/middleware/gzip.rb:9:in `new'
        from /home/jbellone/.gem/ruby/2.2.2/gems/ridley-4.2.0/lib/ridley/middleware/gzip.rb:9:in `on_complete'
        from /home/jbellone/.gem/ruby/2.2.2/bundler/gems/faraday-5d40163dd97c/lib/faraday/response.rb:9:in `block in c
all'
        from /home/jbellone/.gem/ruby/2.2.2/bundler/gems/faraday-5d40163dd97c/lib/faraday/response.rb:57:in `on_comple
te'
        from /home/jbellone/.gem/ruby/2.2.2/bundler/gems/faraday-5d40163dd97c/lib/faraday/response.rb:8:in `call'
        from /home/jbellone/.gem/ruby/2.2.2/bundler/gems/faraday-5d40163dd97c/lib/faraday/response.rb:8:in `call'
        from /home/jbellone/.gem/ruby/2.2.2/bundler/gems/faraday-5d40163dd97c/lib/faraday/rack_builder.rb:139:in `buil
d_response'
        from /home/jbellone/.gem/ruby/2.2.2/bundler/gems/faraday-5d40163dd97c/lib/faraday/connection.rb:377:in `run_re
quest'
        from /home/jbellone/.gem/ruby/2.2.2/bundler/gems/faraday-5d40163dd97c/lib/faraday/connection.rb:140:in `get'
        from /home/jbellone/.gem/ruby/2.2.2/gems/berkshelf-api-client-1.3.0/lib/berkshelf/api_client/connection.rb:62:
in `universe'
        from /home/jbellone/.gem/ruby/2.2.2/gems/berkshelf-3.2.4/lib/berkshelf/source.rb:22:in `build_universe'
        from /home/jbellone/.gem/ruby/2.2.2/gems/berkshelf-3.2.4/lib/berkshelf/installer.rb:21:in `block (2 levels) in
 build_universe'
```