### PR TITLE
Update faraday dep

### DIFF
--- a/berkshelf-api-client.gemspec
+++ b/berkshelf-api-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.9.0"
+  spec.add_dependency "faraday", "~> 0.9.1"
   spec.add_dependency "httpclient", "~> 2.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Applying changes from issue https://github.com/berkshelf/berkshelf-api-client/issues/9

**Problem Description**
All this is coming since internally at Chef we ship `chefdk` with the latest version of `berkshelf` and this version doesn’t work so well with supermarket. 

In the old world when you try to run `berks install` it was using the ENV `SSL_CERT_FILE` just fine, but not anymore. There was a change on the way berks hit the supermarket `universe`, before it was using `Net::HTTP` but now it is using `HTTPClient` (here the PR that changed that behavior https://github.com/berkshelf/berkshelf-api-client/commit/436ab8458ffb64768df1f29624e0723836e89e79)

### Replicating the Issue:
**Supermarket Server:** 33.33.33.12

Running `berks install` without the `faraday` fix:
```
 ➜  ssl-test-dep git:(master) ✗ SSL_CERT_FILE=/opt/chefdk/embedded/ssl/certs/cacert.pem chef exec berks install
Resolving cookbook dependencies...
Fetching 'ssl-test-dep' from source at .
Fetching cookbook index from https://33.33.33.12...
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/session.rb:307:in `connect': SSL_connect returned=1 errno=0 state=error: certificate verify failed (Faraday::SSLError)
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/session.rb:307:in `ssl_connect'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/session.rb:755:in `block in connect'
	from /opt/chefdk/embedded/lib/ruby/2.1.0/timeout.rb:91:in `block in timeout'
	from /opt/chefdk/embedded/lib/ruby/2.1.0/timeout.rb:101:in `call'
	from /opt/chefdk/embedded/lib/ruby/2.1.0/timeout.rb:101:in `timeout'
	from /opt/chefdk/embedded/lib/ruby/2.1.0/timeout.rb:127:in `timeout'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/session.rb:746:in `connect'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/session.rb:612:in `query'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/session.rb:164:in `query'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient.rb:1191:in `do_get_block'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient.rb:974:in `block in do_request'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient.rb:1082:in `protect_keep_alive_disconnected'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient.rb:969:in `do_request'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient.rb:822:in `request'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/faraday-0.9.1/lib/faraday/adapter/httpclient.rb:33:in `call'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/faraday-0.9.1/lib/faraday/request/retry.rb:110:in `call'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/faraday-0.9.1/lib/faraday/response.rb:8:in `call'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/faraday-0.9.1/lib/faraday/response.rb:8:in `call'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/faraday-0.9.1/lib/faraday/rack_builder.rb:139:in `build_response'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/faraday-0.9.1/lib/faraday/connection.rb:377:in `run_request'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/faraday-0.9.1/lib/faraday/connection.rb:140:in `get'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/berkshelf-api-client-1.3.0/lib/berkshelf/api_client/connection.rb:62:in `universe'
	from /opt/chefdk/embedded/apps/berkshelf/lib/berkshelf/source.rb:22:in `build_universe'
	from /opt/chefdk/embedded/apps/berkshelf/lib/berkshelf/installer.rb:21:in `block (2 levels) in build_universe'
```

Applying the fix: (https://github.com/lostisland/faraday/pull/494)
```
➜  github  git clone https://github.com/lostisland/faraday.git
Cloning into 'faraday'...
remote: Counting objects: 6432, done.
remote: Total 6432 (delta 0), reused 0 (delta 0), pack-reused 6432
Receiving objects: 100% (6432/6432), 1.38 MiB | 863.00 KiB/s, done.
Resolving deltas: 100% (3076/3076), done.
Checking connectivity... done.
➜  github  cd faraday
➜  faraday git:(master) chef gem build faraday.gemspec
WARNING:  no description specified
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: faraday
  Version: 0.9.1
  File: faraday-0.9.1.gem
➜  faraday git:(master) chef gem install faraday-0.9.1.gem
Successfully installed faraday-0.9.1
1 gem installed
➜  faraday git:(master)
``` 

Then running `berks install` works!
```
 ➜  ssl-test-dep git:(master) ✗ SSL_CERT_FILE=/opt/chefdk/embedded/ssl/certs/cacert.pem chef exec berks install
Resolving cookbook dependencies...
Fetching 'ssl-test-dep' from source at .
Fetching cookbook index from https://33.33.33.12...
Installing ssl-test (0.1.0) from https://33.33.33.12 ([opscode] https://33.33.33.12:443/api/v1)
Using ssl-test-dep (0.1.0) from source at .
```