### PR TITLE
Make httpclient pin less restrictive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,5 @@ group :guard do
 end
 
 group :test do
-  gem "berkshelf-api", "~> 1.2"
+  gem "berkshelf-api", "~> 2.0"
 end

--- a/berkshelf-api-client.gemspec
+++ b/berkshelf-api-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 0.9.1"
-  spec.add_dependency "httpclient", "~> 2.6.0"
+  spec.add_dependency "httpclient", "~> 2.6"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Versions of httpclient below 2.7.1 use obsolete methods and dump warnings to stdout in ruby 2.3. This will allow the client to support versions higher than 2.6

https://github.com/nahi/httpclient/blob/master/CHANGELOG.md#changes-in-271