### PR TITLE
Fix an error message by referencing URL as an instance variable

### DIFF
--- a/lib/berkshelf/api_client/chef_server_connection.rb
+++ b/lib/berkshelf/api_client/chef_server_connection.rb
@@ -21,7 +21,7 @@ module Berkshelf::APIClient
         end
       end
     rescue Ridley::Errors::HTTPNotFound
-      raise ServiceNotFound, "service not found at: #{url}"
+      raise ServiceNotFound, "service not found at: #{@url}"
     end
   end
 end


### PR DESCRIPTION
I encountered this error:

```
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/berkshelf-api-client-2.0.2/lib/berkshelf/api_client/chef_server_connection.rb:24:in `rescue in universe': undefined local variable or method `url' for #<Berkshelf::APIClient::ChefServerConnection
```

And eventually traced it to https://github.com/berkshelf/berkshelf-api-client/blob/master/lib/berkshelf/api_client/chef_server_connection.rb#L24 - which calls 'url' in an error message.  

Just missing an '@'.