### PR TITLE
Pass along any headers to Chef::HTTP

### DIFF
--- a/lib/berkshelf/ridley_compat.rb
+++ b/lib/berkshelf/ridley_compat.rb
@@ -10,6 +10,7 @@ module Berkshelf
       opts[:ssl] ||= {}
       chef_opts = {
         rest_timeout: opts[:timeout], # opts[:open_timeout] is ignored on purpose
+        headers: opts[:headers],
         client_name: opts[:client_name],
         signing_key_filename: opts[:client_key],
         ssl_verify_mode: opts[:verify] ? :verify_none : :verify_peer,


### PR DESCRIPTION
Berks' Artifactory integration works via an [auth header](https://github.com/berkshelf/berkshelf/blob/master/lib/berkshelf/source.rb#L68) that should be passed along in HTTP requests.

Confirmed that `berks vendor`s that were failing before are able to fetch cookbooks from our Artifactory server after applying this patch.

Signed-off-by: Jonathan Hartman <j@p4nt5.com>